### PR TITLE
Refactor PharmacophoreGMM

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MolecularGaussians"
 uuid = "be997a16-3bf6-4821-ae3d-37ccaa1f3368"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Dict{Symbol, Vector{Vector{Int64}}} with 4 entries:
   :Aromatic     => [[22, 21, 20, 18, 24, 23]]
 
 julia> pgmm1 = PharmacophoreGMM(mol1; feature_maps=feature_maps1)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians in 4 GMMs with labels:
+PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians labeled:
 [:Acceptor, :NegIonizable, :Donor, :Aromatic]
 
 
 julia> pgmm2 = PharmacophoreGMM(mol2; feature_maps=feature_maps2)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians in 4 GMMs with labels:
+PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians labeled:
 [:Acceptor, :NegIonizable, :Donor, :Aromatic]
 ```
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,8 +13,15 @@ MolecularGaussians
 ```@docs
 PharmacophoreGMM
 feature_maps
+feature_labels
 atoms_to_feature
 transform
+```
+
+## Bond rotation
+
+```@docs
+bondrotate
 ```
 
 ## Feature definitions

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -54,14 +54,15 @@ Building a pharmacophore model proceeds in two stages:
    that realize it. Distinct matches over the same atoms are collapsed to one
    set.
 2. [`PharmacophoreGMM`](@ref) turns each index set into a single Gaussian via
-   [`atoms_to_feature`](@ref) and stores one `IsotropicGMM` per family. The
-   result carries both the per-family mixtures and the underlying molecular
-   graph.
+   [`atoms_to_feature`](@ref), tagging each with its family. The result stores
+   the Gaussians and their parallel family labels alongside the underlying
+   molecular graph.
 
 ## Comparison and alignment
 
-Because a `PharmacophoreGMM` is a family-keyed collection of mixtures,
-comparisons are made family-by-family and summed:
+Because every Gaussian in a `PharmacophoreGMM` carries a family label, overlap
+is restricted to Gaussian pairs whose labels interact — by default only pairs
+sharing a family, so comparisons are made family-by-family and summed:
 
 - `overlap` integrates the product of two mixtures — larger when their features
   coincide in space and type.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,9 +27,10 @@ julia> using Pkg; Pkg.add("MolecularGaussians")
 
 ## Building GMMs from molecules
 
-A [`PharmacophoreGMM`](@ref) holds one `IsotropicGMM` per pharmacophore family.
-The families are chosen by a [`feature_maps`](@ref) dictionary, which
-[`parse_feature_definitions`](@ref) derives from bundled SMARTS definitions.
+A [`PharmacophoreGMM`](@ref) holds one labeled `IsotropicGaussian` per feature,
+each tagged with its pharmacophore family. The families are chosen by a
+[`feature_maps`](@ref) dictionary, which [`parse_feature_definitions`](@ref)
+derives from bundled SMARTS definitions.
 
 ```jldoctest quickstart
 julia> datadir = joinpath(pkgdir(MolecularGaussians), "assets", "data");
@@ -43,11 +44,11 @@ julia> familydefs = parse_feature_definitions();
 julia> families = [:Donor, :Acceptor, :Aromatic, :NegIonizable];
 
 julia> pgmm1 = PharmacophoreGMM(mol1; feature_maps = feature_maps(mol1, familydefs, families))
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians in 4 GMMs with labels:
+PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians labeled:
 [:Acceptor, :NegIonizable, :Donor, :Aromatic]
 
 julia> pgmm2 = PharmacophoreGMM(mol2; feature_maps = feature_maps(mol2, familydefs, families))
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians in 4 GMMs with labels:
+PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians labeled:
 [:Acceptor, :NegIonizable, :Donor, :Aromatic]
 ```
 

--- a/ext/MolecularGaussiansMakieCoreExt.jl
+++ b/ext/MolecularGaussiansMakieCoreExt.jl
@@ -4,7 +4,7 @@ using MolecularGaussians: MolecularGaussians, PharmacophoreGMM
 import MakieCore: plot!
 using MakieCore: @recipe, Theme
 using MolecularGraph: Color, colortype, stick!
-using GaussianMixtureAlignment: gmmdisplay!
+using GaussianMixtureAlignment: gmmdisplay!, IsotropicGMM
 using Colors: Colors
 
 # Fallback palette cycled across GMM components that lack an entry in
@@ -56,14 +56,15 @@ function plot!(md::MolGMMDisplay{<:NTuple{<:Any,<:PharmacophoreGMM{N,T,K}}}) whe
     palette = md[:palette][]
     allkeys = Set{K}()
     for mgmm in mgmms
-        allkeys = allkeys ∪ keys(mgmm.gmms)
+        allkeys = allkeys ∪ Set(mgmm.labels)
     end
     len = length(allkeys)
     for (i,k) in enumerate(allkeys)
         col = isnothing(color) ? (haskey(colors, k) ? colors[k] : palette[(i-1) % len + 1]) : color
         col  = isa(col, Color) ? colortype(col) : col
         for mgmm in mgmms
-            haskey(mgmm.gmms, k) && gmmdisplay!(md, mgmm.gmms[k]; display=disp, color=col, palette=palette)
+            idxs = findall(isequal(k), mgmm.labels)
+            isempty(idxs) || gmmdisplay!(md, IsotropicGMM(mgmm.gaussians[idxs]); display=disp, color=col, palette=palette)
         end
     end
     if md[:show_mol][]

--- a/src/MolecularGaussians.jl
+++ b/src/MolecularGaussians.jl
@@ -24,14 +24,14 @@ using Rotations: AngleAxis, RotMatrix
 using MolecularGraph: MolecularGraph, SDFAtom, SDFMolGraph, SimpleMolGraph, atomnumber, get_prop, is_rotatable, moldisplay, molecular_formula, props, set_prop!, smartstomol, substruct_matches
 using Graphs: Graphs, connected_components, edges, induced_subgraph, neighbors, vertices
 
-using GaussianMixtureAlignment: IsotropicGaussian, IsotropicGMM, AbstractIsotropicMultiGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
+using GaussianMixtureAlignment: IsotropicGaussian, AbstractGMM, AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
 
 # The alignment functions default to AutoForwardDiff(); loading ForwardDiff
 # activates the DifferentiationInterface backend that default requires.
 import ForwardDiff
 
 export local_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
-export PharmacophoreGMM
+export PharmacophoreGMM, feature_labels
 export rocs_align
 
 export AtomType, FeatureDef

--- a/src/MolecularGaussians.jl
+++ b/src/MolecularGaussians.jl
@@ -31,7 +31,7 @@ using GaussianMixtureAlignment: IsotropicGaussian, AbstractGMM, AbstractLabeledI
 import ForwardDiff
 
 export local_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
-export PharmacophoreGMM, feature_labels
+export PharmacophoreGMM, feature_labels, bondrotate
 export rocs_align
 
 export AtomType, FeatureDef

--- a/src/conformers/bondrotate.jl
+++ b/src/conformers/bondrotate.jl
@@ -25,20 +25,25 @@ struct RotatableSubgraph{T}
 end
 
 function RotatableSubgraph(graph::SDFMolGraph, edge::Graphs.Edge)
-    # generate a subgraph after removing the specified edge, and obtain the nodes in each connected component
+    # remove the edge and locate the components that hold each of its endpoints.
+    # Only the endpoints' own component is split; any other components of a
+    # disconnected graph are untouched and irrelevant to this bond's rotation.
     newgraph = deepcopy(graph)
     Graphs.rem_edge!(newgraph, edge)
-    nodesets = connected_components(newgraph)
-    if length(nodesets) != 2
+    comps = connected_components(newgraph)
+    srci = findfirst(c -> edge.src ∈ c, comps)
+    dsti = findfirst(c -> edge.dst ∈ c, comps)
+    if srci == dsti
+        # the endpoints remain connected: the bond lies in a ring
         throw(ArgumentError("Removing the specified edge does not generate two disjoint subgraphs."))
     end
 
     # identify which side of the edge will be rotated (the side with fewer nodes)
-    sort!(nodesets; by=length)
+    nodesets = sort([comps[srci], comps[dsti]]; by=length)
     reverseedge = edge.src ∈ nodesets[2]
     proximalidx = reverseedge ? edge.dst : edge.src
     distalidx = reverseedge ? edge.src : edge.dst
-    
+
     proximalcoords = get_prop(graph, proximalidx, :coords)
     distalcoords = get_prop(graph, distalidx, :coords)
 
@@ -67,3 +72,45 @@ function rotate_edges!(graph::SDFMolGraph, edgeidxs, angles)
 end
 
 rotate_edges(graph, edgeidxs, angles) = rotate_edges!(deepcopy(graph), edgeidxs, angles)
+
+
+## rotation of a PharmacophoreGMM about one of its rotatable bonds
+
+"""
+    bondrotate(pgmm::PharmacophoreGMM, angle, bondidx::Int) -> PharmacophoreGMM
+    bondrotate(pgmm::PharmacophoreGMM, angles, bondidxs::AbstractVector{Int}) -> PharmacophoreGMM
+
+Rotate `pgmm` about its `bondidx`-th rotatable bond by `angle` radians, returning
+a new `PharmacophoreGMM`. The Gaussians the bond moves (`pgmm.bondtogaussians[bondidx]`)
+and the frames of the bonds downstream of it (`pgmm.bondtobonds[bondidx]`) are
+rotated about the bond's axis; every other Gaussian and bond frame is left in place.
+
+The stored `graph` is a rigid reference to the input conformer and is not updated
+by a bond rotation, so after `bondrotate` it no longer matches the moved Gaussians.
+
+The second form applies a sequence of rotations, `angles[k]` about `bondidxs[k]`,
+in order; each rotation acts on the result of the previous one.
+"""
+function bondrotate(pgmm::PharmacophoreGMM{N,T,K,G}, angle, axis, origin, rotatedgaussians, rotatedbonds) where {N,T,K,G}
+    tform = angleaxis_rotation(angle, axis, origin)
+    rot = RotMatrix(AngleAxis(angle, axis...))
+    newgaussians = IsotropicGaussian{N,T}[i ∈ rotatedgaussians ? tform(g) : g for (i,g) in enumerate(pgmm.gaussians)]
+    # axes are directions (rotate by the linear part only); origins are points
+    newaxes = SVector{N,T}[i ∈ rotatedbonds ? SVector{N,T}(rot*a) : a for (i,a) in enumerate(pgmm.axes)]
+    neworigins = SVector{N,T}[i ∈ rotatedbonds ? SVector{N,T}(tform(o)) : o for (i,o) in enumerate(pgmm.origins)]
+    return PharmacophoreGMM{N,T,K,G}(newgaussians, pgmm.labels, pgmm.graph, pgmm.σfun, pgmm.ϕfun,
+                                     pgmm.feature_maps, newaxes, neworigins, pgmm.bondtogaussians, pgmm.bondtobonds)
+end
+
+bondrotate(pgmm::PharmacophoreGMM, angle, bondidx::Int) =
+    bondrotate(pgmm, angle, pgmm.axes[bondidx], pgmm.origins[bondidx], pgmm.bondtogaussians[bondidx], pgmm.bondtobonds[bondidx])
+
+function bondrotate(pgmm::PharmacophoreGMM, angles, bondidxs::AbstractVector{Int})
+    length(angles) == length(bondidxs) ||
+        throw(DimensionMismatch("number of angles ($(length(angles))) must match number of bond indices ($(length(bondidxs)))"))
+    newpgmm = pgmm
+    for (angle, bondidx) in zip(angles, bondidxs)
+        newpgmm = bondrotate(newpgmm, angle, bondidx)
+    end
+    return newpgmm
+end

--- a/src/conformers/conformers.jl
+++ b/src/conformers/conformers.jl
@@ -76,7 +76,7 @@ _overlap_tform(res::ROCSAlignmentResult) = (res.minimum, res.tform)
 _overlap_tform(res::Tuple) = (res[1], res[2])            # local_align
 _overlap_tform(res) = (res.upperbound, res.tform_params) # gogma_align / tiv_gogma_align
 
-function align_conformers(confs::AbstractVector{<:G}, template::L; alignfun = local_align, kwargs...) where {G<:PharmacophoreGMM, L<:AbstractIsotropicMultiGMM}
+function align_conformers(confs::AbstractVector{<:G}, template::L; alignfun = local_align, kwargs...) where {G<:PharmacophoreGMM, L<:AbstractGMM}
     bestconf = confs[1]
     bestidx = 1
     bestolap = Inf

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -2,27 +2,58 @@ import Base: eltype
 
 # PharmacophoreGMM
 
-struct PharmacophoreGMM{N,T<:Real,K,G<:SimpleMolGraph} <: AbstractIsotropicMultiGMM{N,T,K}
-    gmms::Dict{K, IsotropicGMM{N,T}}
+"""
+    PharmacophoreGMM
+
+A labeled isotropic Gaussian mixture built from a molecule. Every Gaussian in
+`gaussians` carries a parallel feature label in `labels`, so overlap between two
+`PharmacophoreGMM`s is restricted to Gaussian pairs whose labels interact (by
+default, only equal labels; see [`overlap`](@ref) for the `interactions`
+keyword). The two vectors have equal length.
+
+The molecular `graph` is kept alongside the labeled vectors so the molecule can
+still be drawn and its formula reported. `σfun`, `ϕfun`, and `feature_maps`
+record how the Gaussians were built.
+"""
+struct PharmacophoreGMM{N,T<:Real,K,G<:SimpleMolGraph} <: AbstractLabeledIsotropicGMM{N,T,K}
+    gaussians::Vector{IsotropicGaussian{N,T}}
+    labels::Vector{K}
     graph::G
     σfun::Function
     ϕfun::Function
     feature_maps::Dict{K, Vector{Vector{Int}}}
+    function PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps) where {N,T,K,G}
+        length(gaussians) == length(labels) ||
+            throw(DimensionMismatch("number of Gaussians ($(length(gaussians))) must match number of labels ($(length(labels)))"))
+        return new{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps)
+    end
 end
 
-eltype(::Type{PharmacophoreGMM{N,T,K,G}}) where {N,T,K,G} = Pair{K, IsotropicGMM{N,T}}
+function PharmacophoreGMM(gaussians::AbstractVector{IsotropicGaussian{N,T}}, labels::AbstractVector{K},
+                          graph::G, σfun, ϕfun, feature_maps) where {N,T,K,G<:SimpleMolGraph}
+    return PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps)
+end
+
+eltype(::Type{PharmacophoreGMM{N,T,K,G}}) where {N,T,K,G} = IsotropicGaussian{N,T}
+
+"""
+    feature_labels(pgmm::PharmacophoreGMM)
+
+Return the distinct feature labels present in `pgmm`, in first-appearance order.
+"""
+feature_labels(pgmm::PharmacophoreGMM) = unique(pgmm.labels)
 
 """
     PharmacophoreGMM(mol; σfun=vdw_volume_sigma, ϕfun=a->one(typeof(vdw_radius(a))), feature_maps=…)
 
-Build a `PharmacophoreGMM` from a molecule or subgraph `mol`, with one `IsotropicGMM`
-per molecular-feature family named in `feature_maps`.
+Build a `PharmacophoreGMM` from a molecule or subgraph `mol`: one labeled
+`IsotropicGaussian` per molecular-feature set named in `feature_maps`.
 
 `feature_maps` maps each feature family (a `Symbol`) to a list of node-index sets; each
-set is collapsed into a single `IsotropicGaussian` feature by `atoms_to_feature`. By
-default it places one single-atom `:Volume` feature on every heavy atom of `mol`.
-`feature_maps` derives pharmacophore families (donors, acceptors, rings, …) from feature
-definitions.
+set is collapsed into a single `IsotropicGaussian` feature by `atoms_to_feature` and
+labeled with its family. By default it places one single-atom `:Volume` feature on every
+heavy atom of `mol`. `feature_maps` derives pharmacophore families (donors, acceptors,
+rings, …) from feature definitions.
 
 `ϕfun(atom)` gives an atom's amplitude and `σfun(atom, ϕ)` its width; see
 `atoms_to_feature` for how they combine over multi-atom feature sets.
@@ -33,7 +64,7 @@ definitions.
 julia> mol = sdftomol(joinpath(pkgdir(MolecularGaussians), "assets", "data", "E1050_3d.sdf"));
 
 julia> PharmacophoreGMM(mol)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 28 Gaussians in 1 GMMs with labels:
+PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 28 Gaussians labeled:
 [:Volume]
 ```
 """
@@ -43,34 +74,30 @@ function PharmacophoreGMM(mol::SDFMolGraph;
                           feature_maps::Dict{K,Vector{Vector{Int}}} = Dict{Symbol,Vector{Vector{Int}}}(:Volume => [[i] for i in heavy_atom_idxs(mol)])) where K
     N = length(props(mol,1).coords)
     T = eltype(props(mol,1).coords)
-    # add a GMM for each type of feature
-    gmms = Dict{Symbol,IsotropicGMM{N,T}}()
+    gaussians = IsotropicGaussian{N,T}[]
+    labels = K[]
     for (feature, nodesets) in feature_maps
-        feats = IsotropicGaussian{N,T}[]
         for set in nodesets
-            push!(feats, atoms_to_feature(mol, set; σfun=σfun, ϕfun=ϕfun))
+            push!(gaussians, atoms_to_feature(mol, set; σfun=σfun, ϕfun=ϕfun))
+            push!(labels, feature)
         end
-        push!(gmms, Pair(feature, IsotropicGMM(feats)))
     end
-    return PharmacophoreGMM(gmms, mol, σfun, ϕfun, feature_maps)
+    return PharmacophoreGMM(gaussians, labels, mol, σfun, ϕfun, feature_maps)
 end
 
+# GaussianMixtureAlignment's generic `*`/`+` on AbstractLabeledIsotropicGMM
+# return a bare LabeledIsotropicGMM, dropping the graph and feature metadata.
+# These methods keep the PharmacophoreGMM type and carry those fields through.
 function  Base.:*(R::AbstractMatrix{W}, x::PharmacophoreGMM{N,V,K,G}) where {N,V,K,G,W}
     numtype = promote_type(V, W)
-    gmmdict = Dict{K, IsotropicGMM{N,numtype}}()
-    for (key, gmm) in x.gmms
-        push!(gmmdict, key=>R*gmm)
-    end
-    return PharmacophoreGMM{N,numtype,K,G}(gmmdict, x.graph, x.σfun, x.ϕfun, x.feature_maps)
+    gaussians = IsotropicGaussian{N,numtype}[R*g for g in x.gaussians]
+    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps)
 end
 
 function  Base.:+(x::PharmacophoreGMM{N,V,K,G}, T::AbstractVector{W}) where {N,V,K,G,W}
     numtype = promote_type(V, W)
-    gmmdict = Dict{K, IsotropicGMM{N,numtype}}()
-    for  (key, gmm) in x.gmms
-        push!(gmmdict, key=>gmm+T)
-    end
-    return PharmacophoreGMM{N,numtype,K,G}(gmmdict, x.graph, x.σfun, x.ϕfun, x.feature_maps)
+    gaussians = IsotropicGaussian{N,numtype}[g+T for g in x.gaussians]
+    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps)
 end
 
 Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
@@ -80,15 +107,12 @@ Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
 
 Apply the transformation `tform` to every Gaussian of `pgmm` and to its
 underlying molecular graph, returning a new `PharmacophoreGMM`. `tform` is
-called as `tform(gmm)` on each per-family `IsotropicGMM` and must map a set of
-3-D points rigidly (e.g. an `AffineMap` from CoordinateTransformations).
+called as `tform(g)` on each `IsotropicGaussian` and must map a set of 3-D
+points rigidly (e.g. an `AffineMap` from CoordinateTransformations).
 """
-function transform(pgmm::PharmacophoreGMM{N,T,K,G}, tform) where {N,T,K,G}
-    newgmms = Dict{K, IsotropicGMM{N,T}}()
-    for (key, gmm) in pgmm.gmms
-        push!(newgmms, key => tform(gmm))
-    end
-    return PharmacophoreGMM{N,T,K,G}(newgmms, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps)
+function transform(pgmm::PharmacophoreGMM, tform)
+    gaussians = [tform(g) for g in pgmm.gaussians]
+    return PharmacophoreGMM(gaussians, pgmm.labels, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps)
 end
 
 # `public` is a soft keyword only on Julia 1.11+; guard so the module still
@@ -101,12 +125,12 @@ end
 
 Base.show(io::IO, pgmm::PharmacophoreGMM) = print(io,
     summary(pgmm),
-    " with $(sum(length(gmm.second) for gmm in pgmm)) Gaussians in $(length(pgmm)) GMMs"
+    " with $(length(pgmm.gaussians)) Gaussians labeled $(feature_labels(pgmm))"
 )
 
 Base.show(io::IO, ::MIME"text/plain", pgmm::PharmacophoreGMM) = print(io,
     summary(pgmm),
     " from molecule with formula $(molecular_formula(pgmm.graph))",
-    " with $(sum(length(gmm.second) for gmm in pgmm)) Gaussians in $(length(pgmm)) GMMs with labels:\n",
-    "$([label for (label, gmm) in pgmm.gmms])"
+    " with $(length(pgmm.gaussians)) Gaussians labeled:\n",
+    "$(feature_labels(pgmm))"
 )

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -8,7 +8,7 @@ import Base: eltype
 A labeled isotropic Gaussian mixture built from a molecule. Every Gaussian in
 `gaussians` carries a parallel feature label in `labels`, so overlap between two
 `PharmacophoreGMM`s is restricted to Gaussian pairs whose labels interact (by
-default, only equal labels; see [`overlap`](@ref) for the `interactions`
+default, only equal labels; see `overlap` for the `interactions`
 keyword). The two vectors have equal length.
 
 The molecular `graph` is kept alongside the labeled vectors so the molecule can

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -14,6 +14,12 @@ keyword). The two vectors have equal length.
 The molecular `graph` is kept alongside the labeled vectors so the molecule can
 still be drawn and its formula reported. `σfun`, `ϕfun`, and `feature_maps`
 record how the Gaussians were built.
+
+The model also carries the geometry of its rotatable bonds so it can be flexed
+without the graph (see [`bondrotate`](@ref)). `axes[b]` and `origins[b]` are the
+direction and a point on the `b`-th bond's rotation axis; `bondtogaussians[b]`
+lists the Gaussians that bond moves and `bondtobonds[b]` the bonds downstream of
+it. These four vectors have equal length (one entry per rotatable bond).
 """
 struct PharmacophoreGMM{N,T<:Real,K,G<:SimpleMolGraph} <: AbstractLabeledIsotropicGMM{N,T,K}
     gaussians::Vector{IsotropicGaussian{N,T}}
@@ -22,16 +28,25 @@ struct PharmacophoreGMM{N,T<:Real,K,G<:SimpleMolGraph} <: AbstractLabeledIsotrop
     σfun::Function
     ϕfun::Function
     feature_maps::Dict{K, Vector{Vector{Int}}}
-    function PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps) where {N,T,K,G}
+    axes::Vector{SVector{N,T}}
+    origins::Vector{SVector{N,T}}
+    bondtogaussians::Vector{Vector{Int}}
+    bondtobonds::Vector{Vector{Int}}
+    function PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps,
+                                       axes, origins, bondtogaussians, bondtobonds) where {N,T,K,G}
         length(gaussians) == length(labels) ||
             throw(DimensionMismatch("number of Gaussians ($(length(gaussians))) must match number of labels ($(length(labels)))"))
-        return new{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps)
+        length(axes) == length(origins) == length(bondtogaussians) == length(bondtobonds) ||
+            throw(DimensionMismatch("bond-geometry vectors (axes, origins, bondtogaussians, bondtobonds) must have equal length"))
+        return new{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps, axes, origins, bondtogaussians, bondtobonds)
     end
 end
 
 function PharmacophoreGMM(gaussians::AbstractVector{IsotropicGaussian{N,T}}, labels::AbstractVector{K},
-                          graph::G, σfun, ϕfun, feature_maps) where {N,T,K,G<:SimpleMolGraph}
-    return PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps)
+                          graph::G, σfun, ϕfun, feature_maps,
+                          axes, origins, bondtogaussians, bondtobonds) where {N,T,K,G<:SimpleMolGraph}
+    return PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps,
+                                     axes, origins, bondtogaussians, bondtobonds)
 end
 
 eltype(::Type{PharmacophoreGMM{N,T,K,G}}) where {N,T,K,G} = IsotropicGaussian{N,T}
@@ -44,16 +59,22 @@ Return the distinct feature labels present in `pgmm`, in first-appearance order.
 feature_labels(pgmm::PharmacophoreGMM) = unique(pgmm.labels)
 
 """
-    PharmacophoreGMM(mol; σfun=vdw_volume_sigma, ϕfun=a->one(typeof(vdw_radius(a))), feature_maps=…)
+    PharmacophoreGMM(mol; combineatoms=true, rigid=false,
+                          σfun=vdw_volume_sigma, ϕfun=a->one(typeof(vdw_radius(a))),
+                          feature_maps=…)
 
-Build a `PharmacophoreGMM` from a molecule or subgraph `mol`: one labeled
-`IsotropicGaussian` per molecular-feature set named in `feature_maps`.
+Build a `PharmacophoreGMM` from a molecule or subgraph `mol`: one or more labeled
+`IsotropicGaussian`s per molecular-feature set named in `feature_maps`.
 
-`feature_maps` maps each feature family (a `Symbol`) to a list of node-index sets; each
-set is collapsed into a single `IsotropicGaussian` feature by `atoms_to_feature` and
-labeled with its family. By default it places one single-atom `:Volume` feature on every
-heavy atom of `mol`. `feature_maps` derives pharmacophore families (donors, acceptors,
-rings, …) from feature definitions.
+`feature_maps` maps each feature family (a `Symbol`) to a list of node-index sets. By
+default it places one single-atom `:Volume` feature on every heavy atom of `mol`;
+`feature_maps` derives pharmacophore families (donors, acceptors, rings, …) from feature
+definitions. With `combineatoms=true` (the default) each set is collapsed into a single
+`IsotropicGaussian` by `atoms_to_feature`; with `combineatoms=false` each atom of a set
+gets its own Gaussian, all sharing the set's family label.
+
+The model's rotatable bonds are detected automatically and their geometry recorded so it
+can be flexed by [`bondrotate`](@ref). Pass `rigid=true` to record no rotatable bonds.
 
 `ϕfun(atom)` gives an atom's amplitude and `σfun(atom, ϕ)` its width; see
 `atoms_to_feature` for how they combine over multi-atom feature sets.
@@ -69,35 +90,72 @@ PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18
 ```
 """
 function PharmacophoreGMM(mol::SDFMolGraph;
+                          combineatoms = true,
+                          rigid = false,
                           σfun = vdw_volume_sigma,
                           ϕfun = a -> one(typeof(vdw_radius(a))),
                           feature_maps::Dict{K,Vector{Vector{Int}}} = Dict{Symbol,Vector{Vector{Int}}}(:Volume => [[i] for i in heavy_atom_idxs(mol)])) where K
     N = length(props(mol,1).coords)
     T = eltype(props(mol,1).coords)
+
+    # rotatable-bond frames and, per bond, the atoms and downstream bonds it moves
+    sgs = rigid ? RotatableSubgraph{T}[] : rotablesubgraphs(mol)
+    axes = SVector{N,T}[SVector{N,T}(sg.axis) for sg in sgs]
+    origins = SVector{N,T}[SVector{N,T}(sg.origin) for sg in sgs]
+    # a bond's endpoints lie on its rotation axis and so do not move; exclude them
+    bondtoatoms = [filter(a -> a != sg.edge.src && a != sg.edge.dst, sg.vlist) for sg in sgs]
+    bondtobonds = [findall(s -> s.edge.src ∈ sg.vlist && s.edge.dst ∈ sg.vlist, sgs) for sg in sgs]
+    bondtogaussians = [Int[] for _ in sgs]
+
     gaussians = IsotropicGaussian{N,T}[]
     labels = K[]
     for (feature, nodesets) in feature_maps
         for set in nodesets
-            push!(gaussians, atoms_to_feature(mol, set; σfun=σfun, ϕfun=ϕfun))
-            push!(labels, feature)
+            if combineatoms
+                push!(gaussians, atoms_to_feature(mol, set; σfun=σfun, ϕfun=ϕfun))
+                push!(labels, feature)
+                gidx = length(gaussians)
+                for (i, moved) in enumerate(bondtoatoms)
+                    # a combined feature follows the bond when most of its atoms move
+                    count(a -> a ∈ moved, set) >= length(set)/2 && push!(bondtogaussians[i], gidx)
+                end
+            else
+                for a in set
+                    push!(gaussians, atoms_to_feature(mol, [a]; σfun=σfun, ϕfun=ϕfun))
+                    push!(labels, feature)
+                    gidx = length(gaussians)
+                    for (i, moved) in enumerate(bondtoatoms)
+                        a ∈ moved && push!(bondtogaussians[i], gidx)
+                    end
+                end
+            end
         end
     end
-    return PharmacophoreGMM(gaussians, labels, mol, σfun, ϕfun, feature_maps)
+    return PharmacophoreGMM(gaussians, labels, mol, σfun, ϕfun, feature_maps,
+                            axes, origins, bondtogaussians, bondtobonds)
 end
 
 # GaussianMixtureAlignment's generic `*`/`+` on AbstractLabeledIsotropicGMM
 # return a bare LabeledIsotropicGMM, dropping the graph and feature metadata.
 # These methods keep the PharmacophoreGMM type and carry those fields through.
+# Bond `axes` are directions and `origins` are points: rotation moves both, but
+# translation shifts only the points.
 function  Base.:*(R::AbstractMatrix{W}, x::PharmacophoreGMM{N,V,K,G}) where {N,V,K,G,W}
     numtype = promote_type(V, W)
     gaussians = IsotropicGaussian{N,numtype}[R*g for g in x.gaussians]
-    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps)
+    axes = SVector{N,numtype}[R*a for a in x.axes]
+    origins = SVector{N,numtype}[R*o for o in x.origins]
+    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps,
+                                           axes, origins, x.bondtogaussians, x.bondtobonds)
 end
 
 function  Base.:+(x::PharmacophoreGMM{N,V,K,G}, T::AbstractVector{W}) where {N,V,K,G,W}
     numtype = promote_type(V, W)
     gaussians = IsotropicGaussian{N,numtype}[g+T for g in x.gaussians]
-    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps)
+    axes = SVector{N,numtype}[a for a in x.axes]
+    origins = SVector{N,numtype}[o .+ T for o in x.origins]
+    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps,
+                                           axes, origins, x.bondtogaussians, x.bondtobonds)
 end
 
 Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
@@ -108,11 +166,16 @@ Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
 Apply the transformation `tform` to every Gaussian of `pgmm` and to its
 underlying molecular graph, returning a new `PharmacophoreGMM`. `tform` is
 called as `tform(g)` on each `IsotropicGaussian` and must map a set of 3-D
-points rigidly (e.g. an `AffineMap` from CoordinateTransformations).
+points rigidly (e.g. an `AffineMap` from CoordinateTransformations). Bond
+`origins` are mapped as points and `axes` as directions (the transform's linear
+part), recovered as `tform(o + a) - tform(o)`.
 """
 function transform(pgmm::PharmacophoreGMM, tform)
     gaussians = [tform(g) for g in pgmm.gaussians]
-    return PharmacophoreGMM(gaussians, pgmm.labels, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps)
+    origins = [tform(o) for o in pgmm.origins]
+    axes = [tform(o + a) - tform(o) for (o, a) in zip(pgmm.origins, pgmm.axes)]
+    return PharmacophoreGMM(gaussians, pgmm.labels, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun,
+                            pgmm.feature_maps, axes, origins, pgmm.bondtogaussians, pgmm.bondtobonds)
 end
 
 # `public` is a soft keyword only on Julia 1.11+; guard so the module still

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -76,7 +76,8 @@ end
     @test feature_labels(pgmm) == [:Volume]
     # the parallel-vector invariant is enforced at construction.
     @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians, [:Volume],
-        pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps)
+        pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps,
+        pgmm.axes, pgmm.origins, pgmm.bondtogaussians, pgmm.bondtobonds)
     # self-overlap is a regression pin: identity-label interactions reproduce the
     # per-family "only same-key GMMs score" overlap.
     @test MG.overlap(pgmm, pgmm) ≈ 171.00457064028473 rtol=1e-10
@@ -88,6 +89,61 @@ end
     same = MG.overlap(pg, pg)                                        # equal labels only
     crossed = MG.overlap(pg, pg; interactions = Dict((:Donor, :Acceptor) => 1.0))
     @test same != crossed
+end
+
+@testset "PharmacophoreGMM bond rotation" begin
+    mol = sdftomol(joinpath(@__DIR__, "..", "assets", "data", "E1050_3d.sdf"))
+    remove_hydrogens!(mol)
+    pgmm = PharmacophoreGMM(mol)
+    sgs = MG.rotablesubgraphs(mol)
+    # one bond frame per rotatable bond, and the four bond-geometry vectors agree
+    @test length(pgmm.axes) == length(sgs)
+    @test length(pgmm.axes) == length(pgmm.origins) == length(pgmm.bondtogaussians) == length(pgmm.bondtobonds)
+    # the bond-geometry length invariant is enforced at construction
+    @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians, pgmm.labels,
+        pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps,
+        pgmm.axes, pgmm.origins[1:end-1], pgmm.bondtogaussians, pgmm.bondtobonds)
+
+    # rigid=true records no rotatable bonds
+    rig = PharmacophoreGMM(mol; rigid = true)
+    @test isempty(rig.axes) && isempty(rig.bondtogaussians)
+
+    # a disconnected subgraph still builds: a rotatable bond splits only its own
+    # component (this molecule's first-half induced subgraph is disconnected)
+    submol, _ = induced_subgraph(mol, collect(nodeset(mol))[1:Int(floor(end/2))])
+    @test length(connected_components(submol)) > 1
+    @test PharmacophoreGMM(submol) isa PharmacophoreGMM
+
+    b = 1
+    rotated = bondrotate(pgmm, 0.7, b)
+    # exactly the Gaussians the bond maps to are moved; the rest are untouched
+    moved = [i for i in eachindex(pgmm.gaussians) if !(rotated.gaussians[i].μ ≈ pgmm.gaussians[i].μ)]
+    @test sort(moved) ⊆ sort(pgmm.bondtogaussians[b])
+    @test all(rotated.gaussians[i].μ == pgmm.gaussians[i].μ for i in eachindex(pgmm.gaussians) if i ∉ pgmm.bondtogaussians[b])
+    # self-overlap is maximal, so a bond rotation moves the model away from itself
+    @test MG.distance(rotated, pgmm) > 1e-6
+    # +θ then -θ recovers the original; a full turn is the identity
+    @test MG.distance(bondrotate(rotated, -0.7, b), pgmm) < 1e-10
+    @test MG.distance(bondrotate(pgmm, 2π, b), pgmm) < 1e-8
+
+    # rotating the GMM about a bond matches rebuilding it from the graph rotated
+    # about that bond's edge
+    θ = 0.9
+    rebuilt = PharmacophoreGMM(MG.rotate_edge(mol, sgs[b].edge, θ))
+    gmmrot = bondrotate(pgmm, θ, b)
+    @test all(gmmrot.gaussians[k].μ ≈ rebuilt.gaussians[k].μ for k in eachindex(pgmm.gaussians))
+
+    # the sequence form applies rotations in order; mismatched lengths are rejected
+    @test bondrotate(pgmm, [0.3, 0.4], [1, 2]) isa PharmacophoreGMM
+    @test_throws DimensionMismatch bondrotate(pgmm, [0.3], [1, 2])
+
+    # combineatoms=false gives one Gaussian per atom, so a multi-atom feature set
+    # yields more Gaussians than the combined (default) form
+    fm = feature_maps(mol, FAMILY_DEFS, [:Aromatic])
+    natoms = sum(sum(length, sets; init = 0) for sets in values(fm); init = 0)
+    @test any(length(set) > 1 for set in first(values(fm)))       # there is a multi-atom set
+    @test length(PharmacophoreGMM(mol; combineatoms = false, feature_maps = fm).gaussians) == natoms
+    @test length(PharmacophoreGMM(mol; feature_maps = fm).gaussians) < natoms
 end
 
 @testset "atoms_to_feature defaults" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,9 +63,31 @@ end
     fm = feature_maps(mol, FAMILY_DEFS, [:Volume])
     pgmm_fm = PharmacophoreGMM(mol; feature_maps = fm)
     @test pgmm_fm.feature_maps == fm
-    # the type-based eltype agrees with the instance-based one (no stray graph
-    # parameter leaking into the IsotropicGMM element type)
-    @test eltype(typeof(pgmm)) == eltype(pgmm) == Pair{Symbol, MG.IsotropicGMM{3,Float64}}
+    # the type-based eltype agrees with the instance-based one: a PharmacophoreGMM
+    # is a flat labeled GMM, so its element type is the Gaussian, not a keyed pair
+    @test eltype(typeof(pgmm)) == eltype(pgmm) == MG.IsotropicGaussian{3,Float64}
+end
+
+@testset "labeled PharmacophoreGMM" begin
+    mol = sdftomol(joinpath(@__DIR__, "..", "assets", "data", "E1050_3d.sdf"))
+    pgmm = PharmacophoreGMM(mol)
+    # a PharmacophoreGMM is a flat labeled GMM: one label per Gaussian.
+    @test length(pgmm.gaussians) == length(pgmm.labels) == length(pgmm)
+    @test feature_labels(pgmm) == [:Volume]
+    # the parallel-vector invariant is enforced at construction.
+    @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians, [:Volume],
+        pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps)
+    # self-overlap is a regression pin: identity-label interactions reproduce the
+    # per-family "only same-key GMMs score" overlap.
+    @test MG.overlap(pgmm, pgmm) ≈ 171.00457064028473 rtol=1e-10
+
+    # cross-label interactions are a new capability the per-family Dict design
+    # could not express: distinct families only overlap when paired explicitly.
+    fm = feature_maps(mol, FAMILY_DEFS, [:Donor, :Acceptor])
+    pg = PharmacophoreGMM(mol; feature_maps = fm)
+    same = MG.overlap(pg, pg)                                        # equal labels only
+    crossed = MG.overlap(pg, pg; interactions = Dict((:Donor, :Acceptor) => 1.0))
+    @test same != crossed
 end
 
 @testset "atoms_to_feature defaults" begin
@@ -385,18 +407,18 @@ end
 
 @testset "ExplicitImports" begin
     # `test_explicit_imports` also checks the MakieCore extension. The ignored
-    # names have no public API in their defining packages: AbstractIsotropicMultiGMM,
-    # ROCSAlignmentResult, centroid, distance, local_align, tanimoto
-    # (GaussianMixtureAlignment) are the internals the core builds on; @recipe,
-    # Theme, plot! (MakieCore) are the recipe interface and Color, colortype
-    # (MolecularGraph) the color plumbing the extension builds on — the same
-    # coupling Aqua's piracy check exempts. The two public-ness checks resolve
-    # "public" accurately only on Julia 1.11+, so they are gated by version; the
-    # other five checks run everywhere.
+    # names have no public API in their defining packages: AbstractGMM,
+    # AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, distance,
+    # local_align, tanimoto (GaussianMixtureAlignment) are the internals the core
+    # builds on; @recipe, Theme, plot! (MakieCore) are the recipe interface and
+    # Color, colortype (MolecularGraph) the color plumbing the extension builds
+    # on — the same coupling Aqua's piracy check exempts. The two public-ness
+    # checks resolve "public" accurately only on Julia 1.11+, so they are gated by
+    # version; the other five checks run everywhere.
     test_explicit_imports(MolecularGaussians;
         all_explicit_imports_are_public = VERSION >= v"1.11" ?
-            (; ignore = (:AbstractIsotropicMultiGMM, :ROCSAlignmentResult, :centroid,
-                         :distance, :local_align, :tanimoto, Symbol("@recipe"),
+            (; ignore = (:AbstractGMM, :AbstractLabeledIsotropicGMM, :ROCSAlignmentResult,
+                         :centroid, :distance, :local_align, :tanimoto, Symbol("@recipe"),
                          :Theme, :plot!, :Color, :colortype)) : false,
         all_qualified_accesses_are_public = VERSION >= v"1.11",
     )


### PR DESCRIPTION
This reworks PharmacophoreGMM from an `AbstractMultiIsotropicGMM` (a Dict of per-family IsotropicGMMs) into an `AbstactLabeledIsotropicGMM` (a single labeled flat GMM (flat Gaussian vector + parallel label vector) with GMM-level bond rotations

  - No alignment regression: the default (equal-label interactions) reproduces the prior "only same-key GMMs score" overlap exactly. It also plugs directly into GMA's generic overlap/distance/rocs_align/gogma_align.
  - New capability: an interactions dict lets distinct families overlap (e.g. donor↔acceptor) — impossible with the old design.
  - Bond rotation: the model now records its rotatable-bond geometry (axes, origins, bondtogaussians, bondtobonds); exported bondrotate(pgmm, angle, bondidx) (and a sequence form) rotates a bond's Gaussians and downstream frames, leaving the rest fixed. Builder gains combineatoms=true/rigid=false. Verified to match rebuilding from the graph rotated about that bond.
  - Keeps the molecular `graph`/`σfun`/`ϕfun`/`feature_maps`; `*`/`+`/`transform` preserve the type and carry bond frames (axes as directions, origins as points). Adds & exports `feature_labels`; updates show, the MakieCore extension, docs, and README.
