### PR TITLE
MolecularGraph compatibility fixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MolecularGaussians"
 uuid = "be997a16-3bf6-4821-ae3d-37ccaa1f3368"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]
@@ -29,7 +29,7 @@ ForwardDiff = "0.10, 1"
 GaussianMixtureAlignment = "0.5.1"
 Graphs = "1.8"
 LinearAlgebra = "1.7"
-MakieCore = "0.6, 0.7, 0.8"
+MakieCore = "0.6, 0.7, 0.8, 0.9, 0.10"
 MolecularGraph = "0.17.2, 0.18, 0.19, 0.20, 0.21, 0.22"
 OffsetArrays = "1"
 Rotations = "1.4, 1.5, 1.6, 1.7"

--- a/ext/MolecularGaussiansMakieCoreExt.jl
+++ b/ext/MolecularGaussiansMakieCoreExt.jl
@@ -3,7 +3,7 @@ module MolecularGaussiansMakieCoreExt
 using MolecularGaussians: MolecularGaussians, PharmacophoreGMM
 import MakieCore: plot!
 using MakieCore: @recipe, Theme
-using MolecularGraph: Color, colortype, stick!
+using MolecularGraph: stick!
 using GaussianMixtureAlignment: gmmdisplay!, IsotropicGMM
 using Colors: Colors
 
@@ -20,15 +20,15 @@ const DEFAULT_COLORS = [
 ]
 
 const FEATURE_COLORS = Dict(
-    :Donor         => Color(255, 0,   255),  # magenta
-    :Acceptor      => Color(0,   255, 0  ),  # green
-    :PosIonizable  => Color(255, 0,   0  ),  # red
-    :NegIonizable  => Color(0,   0,   255),  # blue
-    :Hydrophobe    => Color(0,   255, 255),  # cyan
-    :Ring          => Color(255, 128, 255),  # orange
-    :AromaticRing  => Color(255, 64,  0  ),  # brown
-    :Volume        => Color(200, 200, 200),  # light grey
-    :ExcludedVolume=> Color(100, 100, 100),  # dark grey
+    :Donor         => Colors.RGB(255 / 255, 0   / 255, 255 / 255),  # magenta
+    :Acceptor      => Colors.RGB(0   / 255, 255 / 255, 0   / 255),  # green
+    :PosIonizable  => Colors.RGB(255 / 255, 0   / 255, 0   / 255),  # red
+    :NegIonizable  => Colors.RGB(0   / 255, 0   / 255, 255 / 255),  # blue
+    :Hydrophobe    => Colors.RGB(0   / 255, 255 / 255, 255 / 255),  # cyan
+    :Ring          => Colors.RGB(255 / 255, 128 / 255, 255 / 255),  # orange
+    :AromaticRing  => Colors.RGB(255 / 255, 64  / 255, 0   / 255),  # brown
+    :Volume        => Colors.RGB(200 / 255, 200 / 255, 200 / 255),  # light grey
+    :ExcludedVolume=> Colors.RGB(100 / 255, 100 / 255, 100 / 255),  # dark grey
 )
 
 @recipe(MolGMMDisplay, p) do scene
@@ -61,7 +61,6 @@ function plot!(md::MolGMMDisplay{<:NTuple{<:Any,<:PharmacophoreGMM{N,T,K}}}) whe
     len = length(allkeys)
     for (i,k) in enumerate(allkeys)
         col = isnothing(color) ? (haskey(colors, k) ? colors[k] : palette[(i-1) % len + 1]) : color
-        col  = isa(col, Color) ? colortype(col) : col
         for mgmm in mgmms
             idxs = findall(isequal(k), mgmm.labels)
             isempty(idxs) || gmmdisplay!(md, IsotropicGMM(mgmm.gaussians[idxs]); display=disp, color=col, palette=palette)

--- a/src/MolecularGaussians.jl
+++ b/src/MolecularGaussians.jl
@@ -21,8 +21,15 @@ using StaticArrays: SVector
 using CoordinateTransformations: LinearMap, Translation
 using Rotations: AngleAxis, RotMatrix
 
-using MolecularGraph: MolecularGraph, SDFAtom, SDFMolGraph, SimpleMolGraph, atom_number, get_prop, is_rotatable, moldisplay, molecular_formula, props, set_prop!, smartstomol, substruct_matches
+using MolecularGraph: MolecularGraph, SDFAtom, SDFMolGraph, SimpleMolGraph, get_prop, is_rotatable, moldisplay, molecular_formula, props, set_prop!, smartstomol, substruct_matches
 using Graphs: Graphs, connected_components, edges, induced_subgraph, neighbors, vertices
+
+# MolecularGraph renamed `atomnumber` to `atom_number` in v0.19.0.
+@static if pkgversion(MolecularGraph) < v"0.19.0"
+    using MolecularGraph: atomnumber as atom_number
+else
+    using MolecularGraph: atom_number
+end
 
 using GaussianMixtureAlignment: IsotropicGaussian, AbstractGMM, AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
 

--- a/src/MolecularGaussians.jl
+++ b/src/MolecularGaussians.jl
@@ -21,7 +21,7 @@ using StaticArrays: SVector
 using CoordinateTransformations: LinearMap, Translation
 using Rotations: AngleAxis, RotMatrix
 
-using MolecularGraph: MolecularGraph, SDFAtom, SDFMolGraph, SimpleMolGraph, atomnumber, get_prop, is_rotatable, moldisplay, molecular_formula, props, set_prop!, smartstomol, substruct_matches
+using MolecularGraph: MolecularGraph, SDFAtom, SDFMolGraph, SimpleMolGraph, atom_number, get_prop, is_rotatable, moldisplay, molecular_formula, props, set_prop!, smartstomol, substruct_matches
 using Graphs: Graphs, connected_components, edges, induced_subgraph, neighbors, vertices
 
 using GaussianMixtureAlignment: IsotropicGaussian, AbstractGMM, AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -95,8 +95,14 @@ function PharmacophoreGMM(mol::SDFMolGraph;
                           σfun = vdw_volume_sigma,
                           ϕfun = a -> one(typeof(vdw_radius(a))),
                           feature_maps::Dict{K,Vector{Vector{Int}}} = Dict{Symbol,Vector{Vector{Int}}}(:Volume => [[i] for i in heavy_atom_idxs(mol)])) where K
-    N = length(props(mol,1).coords)
-    T = eltype(props(mol,1).coords)
+    # SDFMolGraph coordinates are 3-D Float64, so an empty molecule (e.g. a
+    # side chain with no atoms) still has a well-defined dimension and eltype.
+    if isempty(vertices(mol))
+        N, T = 3, Float64
+    else
+        N = length(props(mol,1).coords)
+        T = eltype(props(mol,1).coords)
+    end
 
     # rotatable-bond frames and, per bond, the atoms and downstream bonds it moves
     sgs = rigid ? RotatableSubgraph{T}[] : rotablesubgraphs(mol)

--- a/src/radius.jl
+++ b/src/radius.jl
@@ -4,7 +4,7 @@
 Van der Waals radius of atom `a`, looked up from
 `MolecularGraph.ATOM_VANDERWAALS_RADII` by atomic number.
 """
-vdw_radius(a::SDFAtom) = MolecularGraph.ATOM_VANDERWAALS_RADII[atomnumber(a.symbol)]
+vdw_radius(a::SDFAtom) = MolecularGraph.ATOM_VANDERWAALS_RADII[atom_number(a.symbol)]
 
 const rocs_amplitude = 2.7
 

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -1,3 +1,10 @@
+@static if (pkgversion(MolecularGraph) < v"0.22")
+    getmass(a::SDFAtom) = a.mass
+else
+    getmass(a::SDFAtom) = a.isotope
+end
+
+
 """
     transformed(tform, x)
 
@@ -8,7 +15,7 @@ preserved.
 """
 function transformed(tform, a::SDFAtom)
     newcoords = tform(a.coords)
-    return SDFAtom(a.symbol, a.charge, a.multiplicity, a.mass, newcoords)
+    return SDFAtom(a.symbol, a.charge, a.multiplicity, getmass(a), newcoords)
 end
 
 function transformed(tform, mol::SDFMolGraph)

--- a/src/transformation.jl
+++ b/src/transformation.jl
@@ -15,7 +15,7 @@ preserved.
 """
 function transformed(tform, a::SDFAtom)
     newcoords = tform(a.coords)
-    return SDFAtom(a.symbol, a.charge, a.multiplicity, getmass(a), newcoords)
+    return SDFAtom(a.symbol, a.charge, a.multiplicity, getmass(a), Vector{eltype(newcoords)}(newcoords))
 end
 
 function transformed(tform, mol::SDFMolGraph)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -211,20 +211,20 @@ end
     # `transformed` maps every atom's coordinates through the tform, preserves the
     # coordinate container type, and leaves the source molecule unmutated.
     mol2 = MG.transformed(tform, mol)
-    @test all(props(mol2, i).coords ≈ tform(props(mol, i).coords) for i in keys(mol.vprops))
+    @test all(props(mol2, i).coords ≈ tform(props(mol, i).coords) for i in vertices(mol))
     @test typeof(props(mol2, 1).coords) == typeof(props(mol, 1).coords)
     @test props(mol, 1).coords == orig1
     # Transforming a PharmacophoreGMM carries the transform into its molecular graph.
     pgmm = PharmacophoreGMM(mol)
     pgmm2 = MG.transform(pgmm, tform)
-    @test all(props(pgmm2.graph, i).coords ≈ tform(props(mol, i).coords) for i in keys(mol.vprops))
+    @test all(props(pgmm2.graph, i).coords ≈ tform(props(mol, i).coords) for i in vertices(mol))
     # `transform` accepts non-affine transforms too (rotation-only, translation-only).
     lin = LinearMap(RotationVec(0.3, -0.2, 0.5))
     tr = Translation(SVector(1.0, 2.0, 3.0))
     pgmm_lin = MG.transform(pgmm, lin)
     pgmm_tr = MG.transform(pgmm, tr)
-    @test all(props(pgmm_lin.graph, i).coords ≈ lin(props(mol, i).coords) for i in keys(mol.vprops))
-    @test all(props(pgmm_tr.graph, i).coords ≈ tr(props(mol, i).coords) for i in keys(mol.vprops))
+    @test all(props(pgmm_lin.graph, i).coords ≈ lin(props(mol, i).coords) for i in vertices(mol))
+    @test all(props(pgmm_tr.graph, i).coords ≈ tr(props(mol, i).coords) for i in vertices(mol))
 end
 
 @testset "PharmacophoreGMM arithmetic" begin
@@ -468,14 +468,15 @@ end
     # local_align, tanimoto (GaussianMixtureAlignment) are the internals the core
     # builds on; @recipe, Theme, plot! (MakieCore) are the recipe interface and
     # Color, colortype (MolecularGraph) the color plumbing the extension builds
-    # on — the same coupling Aqua's piracy check exempts. The two public-ness
-    # checks resolve "public" accurately only on Julia 1.11+, so they are gated by
-    # version; the other five checks run everywhere.
+    # on; SimpleMolGraph (MolecularGraph) is the abstract supertype the core
+    # dispatches on — the same coupling Aqua's piracy check exempts. The two
+    # public-ness checks resolve "public" accurately only on Julia 1.11+, so they
+    # are gated by version; the other five checks run everywhere.
     test_explicit_imports(MolecularGaussians;
         all_explicit_imports_are_public = VERSION >= v"1.11" ?
             (; ignore = (:AbstractGMM, :AbstractLabeledIsotropicGMM, :ROCSAlignmentResult,
                          :centroid, :distance, :local_align, :tanimoto, Symbol("@recipe"),
-                         :Theme, :plot!, :Color, :colortype)) : false,
+                         :Theme, :plot!, :Color, :colortype, :SimpleMolGraph)) : false,
         all_qualified_accesses_are_public = VERSION >= v"1.11",
     )
 end


### PR DESCRIPTION
This fixes a few compatibility issues with MolecularGraph.jl, depending on its version, without restricting compatible versions:

- handles parameter changes for `SDFileAtom` in v0.22
- updates `transformed(tform, a::SDFileAtom)` for compatibility with MolecularGraph v0.22 
- handles the change from `MolecularGraph.atomnumber` to `MolecularGraph.atom_number` in v0.19
- removes dependence on `MolecularGraph.colortype`

