### PR TITLE
Build PharmacophoreGMM from stacked labeled Gaussians

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MolecularGaussians"
 uuid = "be997a16-3bf6-4821-ae3d-37ccaa1f3368"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Tom McGrath <tmcgrath325@gmail.com> and contributors"]
 
 [deps]
@@ -26,7 +26,7 @@ CoordinateTransformations = "0.6"
 Documenter = "1"
 ExplicitImports = "1.15"
 ForwardDiff = "0.10, 1"
-GaussianMixtureAlignment = "0.5.1"
+GaussianMixtureAlignment = "0.6"
 Graphs = "1.8"
 LinearAlgebra = "1.7"
 MakieCore = "0.6, 0.7, 0.8, 0.9, 0.10"

--- a/README.md
+++ b/README.md
@@ -53,25 +53,25 @@ Dict{Symbol, Vector{Vector{Int64}}} with 4 entries:
   :Aromatic     => [[22, 21, 20, 18, 24, 23]]
 
 julia> pgmm1 = PharmacophoreGMM(mol1; feature_maps=feature_maps1)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians labeled:
-[:Acceptor, :NegIonizable, :Donor, :Aromatic]
+PharmacophoreGMM{3, Float64, 2, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 11 stacked Gaussians labeled:
+[:Acceptor, :Donor, :NegIonizable, :Aromatic]
 
 
 julia> pgmm2 = PharmacophoreGMM(mol2; feature_maps=feature_maps2)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians labeled:
-[:Acceptor, :NegIonizable, :Donor, :Aromatic]
+PharmacophoreGMM{3, Float64, 2, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 7 stacked Gaussians labeled:
+[:Acceptor, :Donor, :NegIonizable, :Aromatic]
 ```
 
 ## Compute overlap, L2 distance, and Tanimoto similarity between two GMMs (prior to alignment)
 ```julia
 julia> overlap(pgmm1, pgmm2)
-14.698770009236481
+14.698770012259153
 
 julia> MG.distance(pgmm1, pgmm2)
-8.351551148172856
+8.35155114196818
 
 julia> tanimoto(pgmm1, pgmm2)
-0.6376817879828839
+0.6376817882020468
 ```
 
 ## Find transformation to align GMMs (maximize overlap)

--- a/docs/src/concepts.md
+++ b/docs/src/concepts.md
@@ -53,21 +53,31 @@ Building a pharmacophore model proceeds in two stages:
    molecule and returns, for each requested family, the sets of atom indices
    that realize it. Distinct matches over the same atoms are collapsed to one
    set.
-2. [`PharmacophoreGMM`](@ref) turns each index set into a single Gaussian via
-   [`atoms_to_feature`](@ref), tagging each with its family. The result stores
-   the Gaussians and their parallel family labels alongside the underlying
-   molecular graph.
+2. [`PharmacophoreGMM`](@ref) turns each index set into a feature via
+   [`atoms_to_feature`](@ref), tagging it with its family. Features built from
+   the same atoms are stacked onto one Gaussian, which then carries a width, an
+   amplitude, and a family label per slot — a hydroxyl oxygen, for instance,
+   holds a donor slot and an acceptor slot on a single mean. The result stores
+   these stacked Gaussians alongside the underlying molecular graph.
+
+   Sizing and weighting a family separately from the others is what makes the
+   slots of a stacked Gaussian differ: pass `σfun` and `ϕfun` as `Dict`s keyed
+   by family rather than as single functions.
 
 ## Comparison and alignment
 
-Because every Gaussian in a `PharmacophoreGMM` carries a family label, overlap
-is restricted to Gaussian pairs whose labels interact — by default only pairs
-sharing a family, so comparisons are made family-by-family and summed:
+Because every slot of a `PharmacophoreGMM` carries a family label, overlap is
+restricted to slot pairs whose labels interact — by default only pairs sharing a
+family, so comparisons are made family-by-family and summed:
 
 - `overlap` integrates the product of two mixtures — larger when their features
   coincide in space and type.
 - `distance` is the `L₂` distance between the two density functions.
 - `tanimoto` normalizes overlap into a similarity score in `[0, 1]`.
+
+Stacking pays off here: the distance between two Gaussians is computed once and
+shared by every pairing of their slots, rather than recomputed for each pair of
+features.
 
 These quantities depend on the relative pose of the two molecules. Alignment
 searches for the rigid transformation (rotation and translation) that maximizes

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -27,9 +27,9 @@ julia> using Pkg; Pkg.add("MolecularGaussians")
 
 ## Building GMMs from molecules
 
-A [`PharmacophoreGMM`](@ref) holds one labeled `IsotropicGaussian` per feature,
-each tagged with its pharmacophore family. The families are chosen by a
-[`feature_maps`](@ref) dictionary, which [`parse_feature_definitions`](@ref)
+A [`PharmacophoreGMM`](@ref) holds one Gaussian per set of atoms, stacking a
+slot for every pharmacophore feature those atoms realize. The families are chosen
+by a [`feature_maps`](@ref) dictionary, which [`parse_feature_definitions`](@ref)
 derives from bundled SMARTS definitions.
 
 ```jldoctest quickstart
@@ -44,12 +44,12 @@ julia> familydefs = parse_feature_definitions();
 julia> families = [:Donor, :Acceptor, :Aromatic, :NegIonizable];
 
 julia> pgmm1 = PharmacophoreGMM(mol1; feature_maps = feature_maps(mol1, familydefs, families))
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 13 Gaussians labeled:
-[:Acceptor, :NegIonizable, :Donor, :Aromatic]
+PharmacophoreGMM{3, Float64, 2, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 11 stacked Gaussians labeled:
+[:Acceptor, :Donor, :NegIonizable, :Aromatic]
 
 julia> pgmm2 = PharmacophoreGMM(mol2; feature_maps = feature_maps(mol2, familydefs, families))
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 9 Gaussians labeled:
-[:Acceptor, :NegIonizable, :Donor, :Aromatic]
+PharmacophoreGMM{3, Float64, 2, Symbol, SDFMolGraph} from molecule with formula C18H24O5S with 7 stacked Gaussians labeled:
+[:Acceptor, :Donor, :NegIonizable, :Aromatic]
 ```
 
 ## Overlap, distance, and Tanimoto similarity

--- a/ext/MolecularGaussiansMakieCoreExt.jl
+++ b/ext/MolecularGaussiansMakieCoreExt.jl
@@ -1,10 +1,10 @@
 module MolecularGaussiansMakieCoreExt
 
-using MolecularGaussians: MolecularGaussians, PharmacophoreGMM
+using MolecularGaussians: MolecularGaussians, PharmacophoreGMM, feature_labels
 import MakieCore: plot!
 using MakieCore: @recipe, Theme
 using MolecularGraph: stick!
-using GaussianMixtureAlignment: gmmdisplay!, IsotropicGMM
+using GaussianMixtureAlignment: gmmdisplay!, IsotropicGaussian, IsotropicGMM
 using Colors: Colors
 
 # Fallback palette cycled across GMM components that lack an entry in
@@ -48,7 +48,15 @@ function MolecularGaussians.pharmacophoredisplay(args...; kwargs...)
     return figaxplot
 end
 
-function plot!(md::MolGMMDisplay{<:NTuple{<:Any,<:PharmacophoreGMM{N,T,K}}}) where {N,T,K}
+# Unstack the slots labeled `k` into plain Gaussians. Amplitude-zero slots are padding
+# rather than features, and would otherwise be drawn at their arbitrary padded width.
+function labeled_gmm(mgmm::PharmacophoreGMM{N,T,L,K}, k) where {N,T,L,K}
+    return IsotropicGMM([IsotropicGaussian(g.μ, g.σ[j], g.ϕ[j])
+                         for g in mgmm.gaussians for j in eachindex(g.labels)
+                         if g.labels[j] == k && !iszero(g.ϕ[j])])
+end
+
+function plot!(md::MolGMMDisplay{<:NTuple{<:Any,<:PharmacophoreGMM{N,T,L,K}}}) where {N,T,L,K}
     mgmms = [md[i][] for i=1:length(md)]
     disp = md[:display][]
     color = md[:color][]
@@ -56,14 +64,14 @@ function plot!(md::MolGMMDisplay{<:NTuple{<:Any,<:PharmacophoreGMM{N,T,K}}}) whe
     palette = md[:palette][]
     allkeys = Set{K}()
     for mgmm in mgmms
-        allkeys = allkeys ∪ Set(mgmm.labels)
+        allkeys = allkeys ∪ Set(feature_labels(mgmm))
     end
     len = length(allkeys)
     for (i,k) in enumerate(allkeys)
         col = isnothing(color) ? (haskey(colors, k) ? colors[k] : palette[(i-1) % len + 1]) : color
         for mgmm in mgmms
-            idxs = findall(isequal(k), mgmm.labels)
-            isempty(idxs) || gmmdisplay!(md, IsotropicGMM(mgmm.gaussians[idxs]); display=disp, color=col, palette=palette)
+            gmm = labeled_gmm(mgmm, k)
+            isempty(gmm.gaussians) || gmmdisplay!(md, gmm; display=disp, color=col, palette=palette)
         end
     end
     if md[:show_mol][]

--- a/src/MolecularGaussians.jl
+++ b/src/MolecularGaussians.jl
@@ -31,7 +31,7 @@ else
     using MolecularGraph: atom_number
 end
 
-using GaussianMixtureAlignment: IsotropicGaussian, AbstractGMM, AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
+using GaussianMixtureAlignment: IsotropicGaussian, StackedLabeledGaussian, StackedLabeledIsotropicGMM, AbstractGMM, AbstractStackedLabeledIsotropicGMM, ROCSAlignmentResult, centroid, local_align, rocs_align, gogma_align, tiv_gogma_align, overlap, distance, tanimoto
 
 # The alignment functions default to AutoForwardDiff(); loading ForwardDiff
 # activates the DifferentiationInterface backend that default requires.

--- a/src/conformers/bondrotate.jl
+++ b/src/conformers/bondrotate.jl
@@ -81,25 +81,25 @@ rotate_edges(graph, edgeidxs, angles) = rotate_edges!(deepcopy(graph), edgeidxs,
     bondrotate(pgmm::PharmacophoreGMM, angles, bondidxs::AbstractVector{Int}) -> PharmacophoreGMM
 
 Rotate `pgmm` about its `bondidx`-th rotatable bond by `angle` radians, returning
-a new `PharmacophoreGMM`. The Gaussians the bond moves (`pgmm.bondtogaussians[bondidx]`)
+a new `PharmacophoreGMM`. The components the bond moves (`pgmm.bondtogaussians[bondidx]`)
 and the frames of the bonds downstream of it (`pgmm.bondtobonds[bondidx]`) are
-rotated about the bond's axis; every other Gaussian and bond frame is left in place.
+rotated about the bond's axis; every other component and bond frame is left in place.
 
 The stored `graph` is a rigid reference to the input conformer and is not updated
-by a bond rotation, so after `bondrotate` it no longer matches the moved Gaussians.
+by a bond rotation, so after `bondrotate` it no longer matches the moved components.
 
 The second form applies a sequence of rotations, `angles[k]` about `bondidxs[k]`,
 in order; each rotation acts on the result of the previous one.
 """
-function bondrotate(pgmm::PharmacophoreGMM{N,T,K,G}, angle, axis, origin, rotatedgaussians, rotatedbonds) where {N,T,K,G}
+function bondrotate(pgmm::PharmacophoreGMM{N,T,L,K,G}, angle, axis, origin, rotatedgaussians, rotatedbonds) where {N,T,L,K,G}
     tform = angleaxis_rotation(angle, axis, origin)
     rot = RotMatrix(AngleAxis(angle, axis...))
-    newgaussians = IsotropicGaussian{N,T}[i ∈ rotatedgaussians ? tform(g) : g for (i,g) in enumerate(pgmm.gaussians)]
+    newgaussians = StackedLabeledGaussian{N,T,L,K}[i ∈ rotatedgaussians ? tform(g) : g for (i,g) in enumerate(pgmm.gaussians)]
     # axes are directions (rotate by the linear part only); origins are points
     newaxes = SVector{N,T}[i ∈ rotatedbonds ? SVector{N,T}(rot*a) : a for (i,a) in enumerate(pgmm.axes)]
     neworigins = SVector{N,T}[i ∈ rotatedbonds ? SVector{N,T}(tform(o)) : o for (i,o) in enumerate(pgmm.origins)]
-    return PharmacophoreGMM{N,T,K,G}(newgaussians, pgmm.labels, pgmm.graph, pgmm.σfun, pgmm.ϕfun,
-                                     pgmm.feature_maps, newaxes, neworigins, pgmm.bondtogaussians, pgmm.bondtobonds)
+    return PharmacophoreGMM{N,T,L,K,G}(newgaussians, pgmm.graph, pgmm.σfun, pgmm.ϕfun,
+                                       pgmm.feature_maps, newaxes, neworigins, pgmm.bondtogaussians, pgmm.bondtobonds)
 end
 
 bondrotate(pgmm::PharmacophoreGMM, angle, bondidx::Int) =

--- a/src/features/features.jl
+++ b/src/features/features.jl
@@ -21,7 +21,11 @@ function atoms_to_feature(mol::SDFMolGraph, nodeset; ϕfun = rocs_volume_amplitu
         coordmat = hcat([a.coords for a in atoms]...)
         μ = centroid(coordmat, fill(1/length(atoms), length(atoms)))
         ϕ = sum([ϕfun(a) for a in atoms])/length(atoms)
-        σ = sphere_volume_sigma((sum(x -> x^3, [vdw_radius(a) for a in atoms]))^(1/3), ϕ)
+        # Accumulate the combined volume at the coordinates' precision: `vdw_radius`
+        # reads a Float32 table, and summing cubes there leaves the width dependent on
+        # the order the atoms are listed in.
+        T = eltype(μ)
+        σ = sphere_volume_sigma(sum(a -> T(vdw_radius(a))^3, atoms)^(1/3), ϕ)
     end
     return IsotropicGaussian(μ, σ, ϕ)
 end

--- a/src/gmms.jl
+++ b/src/gmms.jl
@@ -5,79 +5,96 @@ import Base: eltype
 """
     PharmacophoreGMM
 
-A labeled isotropic Gaussian mixture built from a molecule. Every Gaussian in
-`gaussians` carries a parallel feature label in `labels`, so overlap between two
-`PharmacophoreGMM`s is restricted to Gaussian pairs whose labels interact (by
-default, only equal labels; see `overlap` for the `interactions`
-keyword). The two vectors have equal length.
+A stacked labeled isotropic Gaussian mixture built from a molecule. Each component is a
+`StackedLabeledGaussian` centered on one set of atoms and carrying `L` feature slots, with a
+width, an amplitude, and a family label per slot. One point can therefore model several
+physical interactions at once — steric bulk, electrostatics, hydrogen bonding — each sized
+and weighted independently.
 
-The molecular `graph` is kept alongside the labeled vectors so the molecule can
-still be drawn and its formula reported. `σfun`, `ϕfun`, and `feature_maps`
-record how the Gaussians were built.
+Feature sets built from the same atoms share a component. Components realizing fewer than
+`L` features are padded with amplitude-zero slots, which contribute nothing.
 
-The model also carries the geometry of its rotatable bonds so it can be flexed
-without the graph (see [`bondrotate`](@ref)). `axes[b]` and `origins[b]` are the
-direction and a point on the `b`-th bond's rotation axis; `bondtogaussians[b]`
-lists the Gaussians that bond moves and `bondtobonds[b]` the bonds downstream of
-it. These four vectors have equal length (one entry per rotatable bond).
+Overlap between two `PharmacophoreGMM`s sums over the slot pairs whose labels interact (by
+default, only equal labels; see `overlap` for the `interactions` keyword), computing the
+distance between a pair of components once rather than once per pair of features.
+
+The molecular `graph` is kept alongside the components so the molecule can still be drawn
+and its formula reported. `σfun`, `ϕfun`, and `feature_maps` record how the features were
+built.
+
+The model also carries the geometry of its rotatable bonds so it can be flexed without the
+graph (see [`bondrotate`](@ref)). `axes[b]` and `origins[b]` are the direction and a point on
+the `b`-th bond's rotation axis; `bondtogaussians[b]` lists the components that bond moves
+and `bondtobonds[b]` the bonds downstream of it. These four vectors have equal length (one
+entry per rotatable bond).
 """
-struct PharmacophoreGMM{N,T<:Real,K,G<:SimpleMolGraph} <: AbstractLabeledIsotropicGMM{N,T,K}
-    gaussians::Vector{IsotropicGaussian{N,T}}
-    labels::Vector{K}
+struct PharmacophoreGMM{N,T<:Real,L,K,G<:SimpleMolGraph} <: AbstractStackedLabeledIsotropicGMM{N,T,L,K}
+    gaussians::Vector{StackedLabeledGaussian{N,T,L,K}}
     graph::G
-    σfun::Function
-    ϕfun::Function
+    σfun
+    ϕfun
     feature_maps::Dict{K, Vector{Vector{Int}}}
     axes::Vector{SVector{N,T}}
     origins::Vector{SVector{N,T}}
     bondtogaussians::Vector{Vector{Int}}
     bondtobonds::Vector{Vector{Int}}
-    function PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps,
-                                       axes, origins, bondtogaussians, bondtobonds) where {N,T,K,G}
-        length(gaussians) == length(labels) ||
-            throw(DimensionMismatch("number of Gaussians ($(length(gaussians))) must match number of labels ($(length(labels)))"))
+    function PharmacophoreGMM{N,T,L,K,G}(gaussians, graph, σfun, ϕfun, feature_maps,
+                                         axes, origins, bondtogaussians, bondtobonds) where {N,T,L,K,G}
         length(axes) == length(origins) == length(bondtogaussians) == length(bondtobonds) ||
             throw(DimensionMismatch("bond-geometry vectors (axes, origins, bondtogaussians, bondtobonds) must have equal length"))
-        return new{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps, axes, origins, bondtogaussians, bondtobonds)
+        return new{N,T,L,K,G}(gaussians, graph, σfun, ϕfun, feature_maps, axes, origins, bondtogaussians, bondtobonds)
     end
 end
 
-function PharmacophoreGMM(gaussians::AbstractVector{IsotropicGaussian{N,T}}, labels::AbstractVector{K},
+function PharmacophoreGMM(gaussians::AbstractVector{StackedLabeledGaussian{N,T,L,K}},
                           graph::G, σfun, ϕfun, feature_maps,
-                          axes, origins, bondtogaussians, bondtobonds) where {N,T,K,G<:SimpleMolGraph}
-    return PharmacophoreGMM{N,T,K,G}(gaussians, labels, graph, σfun, ϕfun, feature_maps,
-                                     axes, origins, bondtogaussians, bondtobonds)
+                          axes, origins, bondtogaussians, bondtobonds) where {N,T,L,K,G<:SimpleMolGraph}
+    return PharmacophoreGMM{N,T,L,K,G}(gaussians, graph, σfun, ϕfun, feature_maps,
+                                       axes, origins, bondtogaussians, bondtobonds)
 end
 
-eltype(::Type{PharmacophoreGMM{N,T,K,G}}) where {N,T,K,G} = IsotropicGaussian{N,T}
+eltype(::Type{PharmacophoreGMM{N,T,L,K,G}}) where {N,T,L,K,G} = StackedLabeledGaussian{N,T,L,K}
 
 """
     feature_labels(pgmm::PharmacophoreGMM)
 
 Return the distinct feature labels present in `pgmm`, in first-appearance order.
 """
-feature_labels(pgmm::PharmacophoreGMM) = unique(pgmm.labels)
+feature_labels(pgmm::PharmacophoreGMM) = unique(l for g in pgmm.gaussians for l in g.labels)
+
+"""
+    family_function(f, family)
+
+Select the width or amplitude function that applies to a pharmacophore `family`. A plain `f`
+applies to every family; an `AbstractDict` maps each family to its own function and raises a
+`KeyError` for a family it does not cover.
+"""
+family_function(f, family) = f
+family_function(f::AbstractDict, family) = f[family]
 
 """
     PharmacophoreGMM(mol; combineatoms=true, rigid=false,
                           σfun=vdw_volume_sigma, ϕfun=a->one(typeof(vdw_radius(a))),
                           feature_maps=…)
 
-Build a `PharmacophoreGMM` from a molecule or subgraph `mol`: one or more labeled
-`IsotropicGaussian`s per molecular-feature set named in `feature_maps`.
+Build a `PharmacophoreGMM` from a molecule or subgraph `mol`: one labeled feature per
+molecular-feature set named in `feature_maps`, with features sharing a set of atoms stacked
+onto a single component.
 
 `feature_maps` maps each feature family (a `Symbol`) to a list of node-index sets. By
 default it places one single-atom `:Volume` feature on every heavy atom of `mol`;
 `feature_maps` derives pharmacophore families (donors, acceptors, rings, …) from feature
 definitions. With `combineatoms=true` (the default) each set is collapsed into a single
-`IsotropicGaussian` by `atoms_to_feature`; with `combineatoms=false` each atom of a set
-gets its own Gaussian, all sharing the set's family label.
+feature by `atoms_to_feature`; with `combineatoms=false` each atom of a set gets its own
+feature, all sharing the set's family label.
 
-The model's rotatable bonds are detected automatically and their geometry recorded so it
-can be flexed by [`bondrotate`](@ref). Pass `rigid=true` to record no rotatable bonds.
+The model's rotatable bonds are detected automatically and their geometry recorded so it can
+be flexed by [`bondrotate`](@ref). Pass `rigid=true` to record no rotatable bonds.
 
-`ϕfun(atom)` gives an atom's amplitude and `σfun(atom, ϕ)` its width; see
-`atoms_to_feature` for how they combine over multi-atom feature sets.
+`ϕfun(atom)` gives an atom's amplitude and `σfun(atom, ϕ)` its width; see `atoms_to_feature`
+for how they combine over multi-atom feature sets. Passing a `Dict` mapping families to
+functions instead of a single function sizes and weights each family separately, which is
+what makes stacking several features on one atom worthwhile.
 
 # Example
 
@@ -85,7 +102,7 @@ can be flexed by [`bondrotate`](@ref). Pass `rigid=true` to record no rotatable 
 julia> mol = sdftomol(joinpath(pkgdir(MolecularGaussians), "assets", "data", "E1050_3d.sdf"));
 
 julia> PharmacophoreGMM(mol)
-PharmacophoreGMM{3, Float64, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 28 Gaussians labeled:
+PharmacophoreGMM{3, Float64, 1, Symbol, SDFMolGraph} from molecule with formula C18H24O8S2 with 28 stacked Gaussians labeled:
 [:Volume]
 ```
 """
@@ -111,57 +128,70 @@ function PharmacophoreGMM(mol::SDFMolGraph;
     # a bond's endpoints lie on its rotation axis and so do not move; exclude them
     bondtoatoms = [filter(a -> a != sg.edge.src && a != sg.edge.dst, sg.vlist) for sg in sgs]
     bondtobonds = [findall(s -> s.edge.src ∈ sg.vlist && s.edge.dst ∈ sg.vlist, sgs) for sg in sgs]
-    bondtogaussians = [Int[] for _ in sgs]
 
-    gaussians = IsotropicGaussian{N,T}[]
-    labels = K[]
+    # Features built from the same atoms have the same centroid, so they stack onto one
+    # component keyed by that atom set.
+    pointof = Dict{Vector{Int},Int}()
+    atomsets = Vector{Int}[]
+    μs = SVector{N,T}[]
+    σs = Vector{T}[]
+    ϕs = Vector{T}[]
+    labelss = Vector{K}[]
     for (feature, nodesets) in feature_maps
+        σf, ϕf = family_function(σfun, feature), family_function(ϕfun, feature)
         for set in nodesets
-            if combineatoms
-                push!(gaussians, atoms_to_feature(mol, set; σfun=σfun, ϕfun=ϕfun))
-                push!(labels, feature)
-                gidx = length(gaussians)
-                for (i, moved) in enumerate(bondtoatoms)
-                    # a combined feature follows the bond when most of its atoms move
-                    count(a -> a ∈ moved, set) >= length(set)/2 && push!(bondtogaussians[i], gidx)
+            for nodes in (combineatoms ? (collect(set),) : ([a] for a in set))
+                # Sorting canonicalizes both the key and the centroid: summing coordinates
+                # in the order a match happened to report them would put equal atom sets
+                # at means differing in the last bit, and they would not stack.
+                atoms = sort(nodes)
+                feat = atoms_to_feature(mol, atoms; σfun=σf, ϕfun=ϕf)
+                p = get!(pointof, atoms) do
+                    push!(atomsets, atoms)
+                    push!(μs, feat.μ)
+                    push!(σs, T[]); push!(ϕs, T[]); push!(labelss, K[])
+                    length(μs)
                 end
-            else
-                for a in set
-                    push!(gaussians, atoms_to_feature(mol, [a]; σfun=σfun, ϕfun=ϕfun))
-                    push!(labels, feature)
-                    gidx = length(gaussians)
-                    for (i, moved) in enumerate(bondtoatoms)
-                        a ∈ moved && push!(bondtogaussians[i], gidx)
-                    end
-                end
+                push!(σs[p], feat.σ); push!(ϕs[p], feat.ϕ); push!(labelss[p], feature)
             end
         end
     end
-    return PharmacophoreGMM(gaussians, labels, mol, σfun, ϕfun, feature_maps,
+
+    bondtogaussians = [Int[] for _ in sgs]
+    for (b, moved) in enumerate(bondtoatoms)
+        for (p, atoms) in enumerate(atomsets)
+            # a feature follows the bond when at least half of its atoms move
+            count(a -> a ∈ moved, atoms) >= length(atoms)/2 && push!(bondtogaussians[b], p)
+        end
+    end
+
+    gaussians = isempty(μs) ? StackedLabeledGaussian{N,T,1,K}[] :
+        StackedLabeledIsotropicGMM(μs, σs, ϕs, labelss; padσ=one(T)).gaussians
+    return PharmacophoreGMM(gaussians, mol, σfun, ϕfun, feature_maps,
                             axes, origins, bondtogaussians, bondtobonds)
 end
 
-# GaussianMixtureAlignment's generic `*`/`+` on AbstractLabeledIsotropicGMM
-# return a bare LabeledIsotropicGMM, dropping the graph and feature metadata.
+# GaussianMixtureAlignment's generic `*`/`+` on AbstractStackedLabeledIsotropicGMM
+# return a bare StackedLabeledIsotropicGMM, dropping the graph and feature metadata.
 # These methods keep the PharmacophoreGMM type and carry those fields through.
 # Bond `axes` are directions and `origins` are points: rotation moves both, but
 # translation shifts only the points.
-function  Base.:*(R::AbstractMatrix{W}, x::PharmacophoreGMM{N,V,K,G}) where {N,V,K,G,W}
+function  Base.:*(R::AbstractMatrix{W}, x::PharmacophoreGMM{N,V,L,K,G}) where {N,V,L,K,G,W}
     numtype = promote_type(V, W)
-    gaussians = IsotropicGaussian{N,numtype}[R*g for g in x.gaussians]
+    gaussians = StackedLabeledGaussian{N,numtype,L,K}[R*g for g in x.gaussians]
     axes = SVector{N,numtype}[R*a for a in x.axes]
     origins = SVector{N,numtype}[R*o for o in x.origins]
-    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps,
-                                           axes, origins, x.bondtogaussians, x.bondtobonds)
+    return PharmacophoreGMM{N,numtype,L,K,G}(gaussians, x.graph, x.σfun, x.ϕfun, x.feature_maps,
+                                             axes, origins, x.bondtogaussians, x.bondtobonds)
 end
 
-function  Base.:+(x::PharmacophoreGMM{N,V,K,G}, T::AbstractVector{W}) where {N,V,K,G,W}
+function  Base.:+(x::PharmacophoreGMM{N,V,L,K,G}, T::AbstractVector{W}) where {N,V,L,K,G,W}
     numtype = promote_type(V, W)
-    gaussians = IsotropicGaussian{N,numtype}[g+T for g in x.gaussians]
+    gaussians = StackedLabeledGaussian{N,numtype,L,K}[g+T for g in x.gaussians]
     axes = SVector{N,numtype}[a for a in x.axes]
     origins = SVector{N,numtype}[o .+ T for o in x.origins]
-    return PharmacophoreGMM{N,numtype,K,G}(gaussians, x.labels, x.graph, x.σfun, x.ϕfun, x.feature_maps,
-                                           axes, origins, x.bondtogaussians, x.bondtobonds)
+    return PharmacophoreGMM{N,numtype,L,K,G}(gaussians, x.graph, x.σfun, x.ϕfun, x.feature_maps,
+                                             axes, origins, x.bondtogaussians, x.bondtobonds)
 end
 
 Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
@@ -169,18 +199,17 @@ Base.:-(x::PharmacophoreGMM, T::AbstractVector) = x + (-T)
 """
     transform(pgmm::PharmacophoreGMM, tform) -> PharmacophoreGMM
 
-Apply the transformation `tform` to every Gaussian of `pgmm` and to its
-underlying molecular graph, returning a new `PharmacophoreGMM`. `tform` is
-called as `tform(g)` on each `IsotropicGaussian` and must map a set of 3-D
-points rigidly (e.g. an `AffineMap` from CoordinateTransformations). Bond
-`origins` are mapped as points and `axes` as directions (the transform's linear
-part), recovered as `tform(o + a) - tform(o)`.
+Apply the transformation `tform` to every component of `pgmm` and to its underlying
+molecular graph, returning a new `PharmacophoreGMM`. `tform` is called as `tform(g)` on each
+`StackedLabeledGaussian` and must map a set of 3-D points rigidly (e.g. an `AffineMap` from
+CoordinateTransformations). Bond `origins` are mapped as points and `axes` as directions (the
+transform's linear part), recovered as `tform(o + a) - tform(o)`.
 """
 function transform(pgmm::PharmacophoreGMM, tform)
     gaussians = [tform(g) for g in pgmm.gaussians]
     origins = [tform(o) for o in pgmm.origins]
     axes = [tform(o + a) - tform(o) for (o, a) in zip(pgmm.origins, pgmm.axes)]
-    return PharmacophoreGMM(gaussians, pgmm.labels, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun,
+    return PharmacophoreGMM(gaussians, transformed(tform, pgmm.graph), pgmm.σfun, pgmm.ϕfun,
                             pgmm.feature_maps, axes, origins, pgmm.bondtogaussians, pgmm.bondtobonds)
 end
 
@@ -194,12 +223,12 @@ end
 
 Base.show(io::IO, pgmm::PharmacophoreGMM) = print(io,
     summary(pgmm),
-    " with $(length(pgmm.gaussians)) Gaussians labeled $(feature_labels(pgmm))"
+    " with $(length(pgmm.gaussians)) stacked Gaussians labeled $(feature_labels(pgmm))"
 )
 
 Base.show(io::IO, ::MIME"text/plain", pgmm::PharmacophoreGMM) = print(io,
     summary(pgmm),
     " from molecule with formula $(molecular_formula(pgmm.graph))",
-    " with $(length(pgmm.gaussians)) Gaussians labeled:\n",
+    " with $(length(pgmm.gaussians)) stacked Gaussians labeled:\n",
     "$(feature_labels(pgmm))"
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using OffsetArrays: OffsetArray
 using Documenter
 
 using Graphs: induced_subgraph, edges, vertices, connected_components, rem_edge!, neighbors
-using GaussianMixtureAlignment: distance
+using GaussianMixtureAlignment: distance, IsotropicGaussian, LabeledIsotropicGMM
 using MolecularGaussians: nodeset
 
 const MG = MolecularGaussians
@@ -64,20 +64,16 @@ end
     pgmm_fm = PharmacophoreGMM(mol; feature_maps = fm)
     @test pgmm_fm.feature_maps == fm
     # the type-based eltype agrees with the instance-based one: a PharmacophoreGMM
-    # is a flat labeled GMM, so its element type is the Gaussian, not a keyed pair
-    @test eltype(typeof(pgmm)) == eltype(pgmm) == MG.IsotropicGaussian{3,Float64}
+    # is a flat stacked GMM, so its element type is the Gaussian, not a keyed pair
+    @test eltype(typeof(pgmm)) == eltype(pgmm) == MG.StackedLabeledGaussian{3,Float64,1,Symbol}
 end
 
 @testset "labeled PharmacophoreGMM" begin
     mol = sdftomol(joinpath(@__DIR__, "..", "assets", "data", "E1050_3d.sdf"))
     pgmm = PharmacophoreGMM(mol)
-    # a PharmacophoreGMM is a flat labeled GMM: one label per Gaussian.
-    @test length(pgmm.gaussians) == length(pgmm.labels) == length(pgmm)
+    # one component per feature when no two features share a set of atoms
+    @test length(pgmm.gaussians) == length(pgmm) == 28
     @test feature_labels(pgmm) == [:Volume]
-    # the parallel-vector invariant is enforced at construction.
-    @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians, [:Volume],
-        pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps,
-        pgmm.axes, pgmm.origins, pgmm.bondtogaussians, pgmm.bondtobonds)
     # self-overlap is a regression pin: identity-label interactions reproduce the
     # per-family "only same-key GMMs score" overlap.
     @test MG.overlap(pgmm, pgmm) ≈ 171.00457064028473 rtol=1e-10
@@ -91,6 +87,53 @@ end
     @test same != crossed
 end
 
+@testset "stacked PharmacophoreGMM" begin
+    mol = sdftomol(joinpath(@__DIR__, "..", "assets", "data", "E1050_3d.sdf"))
+    families = [:Donor, :Acceptor, :Aromatic, :NegIonizable]
+    fm = feature_maps(mol, FAMILY_DEFS, families)
+    pgmm = PharmacophoreGMM(mol; feature_maps = fm)
+    nfeatures = sum(length, values(fm))
+
+    # Features built from the same atoms — here hydroxyls, which are both donors and
+    # acceptors — share one component, so there are fewer components than features and
+    # the stacking degree is the largest number of features on any one atom set.
+    @test length(pgmm.gaussians) < nfeatures
+    @test pgmm isa PharmacophoreGMM{3,Float64,2,Symbol}
+    @test sum(g -> count(!iszero, g.ϕ), pgmm.gaussians) == nfeatures
+    @test sort(feature_labels(pgmm)) == sort(families)
+    stacked = filter(g -> count(!iszero, g.ϕ) > 1, pgmm.gaussians)
+    @test !isempty(stacked)
+    @test all(sort(collect(g.labels)) == [:Acceptor, :Donor] for g in stacked)
+
+    # Stacking is a representation change, not a modeling change: overlaps match those of
+    # the mean-duplicated labeled model, with and without interaction weights. The two
+    # representations sum the same terms in a different order, so they agree to rounding.
+    unstacked = LabeledIsotropicGMM(
+        [IsotropicGaussian(g.μ, g.σ[j], g.ϕ[j]) for g in pgmm.gaussians
+             for j in eachindex(g.labels) if !iszero(g.ϕ[j])],
+        [l for g in pgmm.gaussians for (j, l) in pairs(g.labels) if !iszero(g.ϕ[j])])
+    @test length(unstacked.gaussians) == nfeatures
+    @test MG.overlap(pgmm, pgmm) ≈ MG.overlap(unstacked, unstacked) rtol=1e-14
+    interactions = Dict((:Donor, :Acceptor) => 0.5, (:Donor, :Donor) => 1.0)
+    @test MG.overlap(pgmm, pgmm; interactions) ≈ MG.overlap(unstacked, unstacked; interactions) rtol=1e-14
+
+    # Padded slots carry zero amplitude and a positive width, and repeat a label the
+    # component already has, so they add no overlap and no new feature label.
+    padded = filter(g -> count(!iszero, g.ϕ) < 2, pgmm.gaussians)
+    @test !isempty(padded)
+    @test all(all(>(0), g.σ) && g.labels[1] == g.labels[2] for g in padded)
+
+    # A Dict of per-family functions sizes and weights each family separately, which is
+    # what distinguishes the stacked slots of one component from each other.
+    σfun = Dict(f => ((a, ϕ) -> 1.0 + i) for (i, f) in enumerate(families))
+    ϕfun = Dict(f => (a -> 1.0 / i) for (i, f) in enumerate(families))
+    perfamily = PharmacophoreGMM(mol; feature_maps = fm, σfun, ϕfun)
+    g = first(x for x in perfamily.gaussians if count(!iszero, x.ϕ) > 1)
+    @test allunique(g.σ) && allunique(g.ϕ)
+    # a family the Dict does not cover is an error, not a silent default
+    @test_throws KeyError PharmacophoreGMM(mol; feature_maps = fm, ϕfun = Dict(:Donor => a -> 1.0))
+end
+
 @testset "PharmacophoreGMM bond rotation" begin
     mol = sdftomol(joinpath(@__DIR__, "..", "assets", "data", "E1050_3d.sdf"))
     remove_hydrogens!(mol)
@@ -100,7 +143,7 @@ end
     @test length(pgmm.axes) == length(sgs)
     @test length(pgmm.axes) == length(pgmm.origins) == length(pgmm.bondtogaussians) == length(pgmm.bondtobonds)
     # the bond-geometry length invariant is enforced at construction
-    @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians, pgmm.labels,
+    @test_throws DimensionMismatch MG.PharmacophoreGMM(pgmm.gaussians,
         pgmm.graph, pgmm.σfun, pgmm.ϕfun, pgmm.feature_maps,
         pgmm.axes, pgmm.origins[1:end-1], pgmm.bondtogaussians, pgmm.bondtobonds)
 
@@ -154,6 +197,12 @@ end
     # build an IsotropicGaussian for both a single-atom and a multi-atom nodeset.
     @test MG.atoms_to_feature(mol, nodes[1:1]) isa MG.IsotropicGaussian
     @test MG.atoms_to_feature(mol, nodes[1:3]) isa MG.IsotropicGaussian
+    # A combined feature is a property of its set of atoms, so listing them in another
+    # order must give the identical width — the van der Waals radii come from a Float32
+    # table, where accumulating the combined volume would otherwise be order-dependent.
+    fwd = MG.atoms_to_feature(mol, nodes[1:5])
+    rev = MG.atoms_to_feature(mol, reverse(nodes[1:5]))
+    @test fwd.σ == rev.σ && fwd.ϕ == rev.ϕ
 end
 
 @testset "PharmacophoreGMM alignment" begin
@@ -464,7 +513,7 @@ end
 @testset "ExplicitImports" begin
     # `test_explicit_imports` also checks the MakieCore extension. The ignored
     # names have no public API in their defining packages: AbstractGMM,
-    # AbstractLabeledIsotropicGMM, ROCSAlignmentResult, centroid, distance,
+    # AbstractStackedLabeledIsotropicGMM, ROCSAlignmentResult, centroid, distance,
     # local_align, tanimoto (GaussianMixtureAlignment) are the internals the core
     # builds on; @recipe, Theme, plot! (MakieCore) are the recipe interface and
     # Color, colortype (MolecularGraph) the color plumbing the extension builds
@@ -474,7 +523,7 @@ end
     # are gated by version; the other five checks run everywhere.
     test_explicit_imports(MolecularGaussians;
         all_explicit_imports_are_public = VERSION >= v"1.11" ?
-            (; ignore = (:AbstractGMM, :AbstractLabeledIsotropicGMM, :ROCSAlignmentResult,
+            (; ignore = (:AbstractGMM, :AbstractStackedLabeledIsotropicGMM, :ROCSAlignmentResult,
                          :centroid, :distance, :local_align, :tanimoto, Symbol("@recipe"),
                          :Theme, :plot!, :Color, :colortype, :SimpleMolGraph)) : false,
         all_qualified_accesses_are_public = VERSION >= v"1.11",


### PR DESCRIPTION
This is intended to improve performance in cases where multiple features (steric, electrostatic, etc) are created for a single atom.

`PharmacophoreGMM` subtypes `AbstractStackedLabeledIsotropicGMM`, so each component is a `StackedLabeledGaussian` carrying one width, amplitude, and family label per slot. Features built from the same atoms share a component, letting one point model several interactions at once with independent sizes and weights, and letting an alignment compute a pair's distance once rather than once per pair of features.

The parallel `labels` vector is gone: labels live in the components, where the inherited `push!`/`pop!` cannot desynchronize them. The type gains a stacking degree parameter, `PharmacophoreGMM{N,T,L,K,G}`.

`sigmafun` and `phifun` accept a `Dict` keyed by family as well as a single function. Without per-family sizes and weights every slot of a component would be identical, which is what makes stacking worth doing.

Overlaps are unchanged: a stacked model and the mean-duplicated one it represents sum the same terms, verified with and without interaction weights.

`atoms_to_feature` now accumulates a multi-atom feature's combined volume at the coordinates' precision. `vdw_radius` reads a Float32 table, and summing cubes there left the width dependent on the order a SMARTS match reported its atoms.